### PR TITLE
Web2 - Connect to API

### DIFF
--- a/api/api.host/Properties/launchSettings.json
+++ b/api/api.host/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Kestrel": {
       "commandName": "Project",
       "environmentVariables": {
-        "APEX_Api__webAddress": "http://localhost:8080",
+        "APEX_Api__allowedOrigins": "http://localhost:5100,http://localhost:3000",
         "APEX_Api__apiAddress": "http://localhost:5100",
         "APEX_Api__cookieDomain": "localhost",
         "APEX_Log__directory": "C:\\Git\\Apex\\logs",

--- a/api/api.host/Startup.fs
+++ b/api/api.host/Startup.fs
@@ -52,10 +52,10 @@ type Startup() =
 
         // ASP.NET
         services.AddCors(fun opt ->
-            let webAddress = __.Configuration.GetValue<string>("Api:WebAddress")
+            let allowedOrigins = __.Configuration.GetValue<string>("Api:AllowedOrigins").Split(',')
             opt.AddPolicy("ApiCorsPolicy", fun builder -> 
                 builder
-                    .WithOrigins(webAddress)
+                    .WithOrigins(allowedOrigins)
                     .AllowAnyMethod()
                     .AllowAnyHeader()
                     .AllowCredentials()

--- a/api/api.model/Configuration.fs
+++ b/api/api.model/Configuration.fs
@@ -17,7 +17,7 @@ type WebServerSettings = {
 [<CLIMutable>]
 type ApiSettings = {
     apiAddress : string
-    webAddress : string
+    allowedOrigins : string
     cookieDomain : string
     cookieName : string
 }
@@ -56,7 +56,7 @@ module AppSettings =
         }
         api = {
             apiAddress = ""
-            webAddress = ""
+            allowedOrigins = ""
             cookieDomain = ""
             cookieName = ""
         }

--- a/web2/src/utilities/api.ts
+++ b/web2/src/utilities/api.ts
@@ -24,7 +24,7 @@ function getConfigParams(apiUrl: string): ConfigurationParameters {
     basePath: apiUrl,
     middleware: [],
     headers: {
-
+      'Content-Type': 'application/json',
     },
     credentials: 'include',
   };


### PR DESCRIPTION
- Updated allowed origins in API
- Updated headers in Web2 client
- Requires updating environment variables in ElasticBeantalk